### PR TITLE
Fixes broken 'Cyphernomicon' document hyperlink

### DIFF
--- a/_mailing_list/cyphernomicon.md
+++ b/_mailing_list/cyphernomicon.md
@@ -1,6 +1,6 @@
 ---
 title: The Cyphernomicon (Cypherpunks Mailing List FAQ)
 external_link: true
-external_url: https://www.cypherpunks.to/faq/cyphernomicron/cyphernomicon.html
+external_url: https://nakamotoinstitute.org/static/docs/cyphernomicon.txt
 order: 4
 ---


### PR DESCRIPTION
Currently, the 'cyphernomicon' document link to https://cypherpunks.to/faq/docs/cyphernomicon.html reports an ERROR 404. I have therefore replaced the url with a working one from the nakamoto institute, which is served in the 'txt' format.

This PR closes #11